### PR TITLE
[0-th enum value JSON serialization] [part 2/2] Fix enum in JSON, option 2)

### DIFF
--- a/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonMessageEncoder.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonMessageEncoder.kt
@@ -39,7 +39,14 @@ internal class JsonMessageEncoder(private val jsonConfig: JsonConfig) : MessageE
             val value = (fd.value as KProperty1<T, *>).get(message)
 
             if (value == null && fd.oneofMember) continue
-            if (!fd.oneofMember && !jsonConfig.outputDefaultValues && fd.type.isDefaultValue(value)) continue
+
+            // For optional enums (mostly relevant for proto2) we serialize the value whenever a value is set,
+            // regardless of whether it's set to a default enum value.
+            val isOptionalEnum = (fd.type is FieldDescriptor.Type.Enum<*> && fd.type.hasPresence)
+            if (isOptionalEnum && value == null) continue
+
+            // Don't serialize other default values unless 'outputDefaultValues' is set.
+            if (!fd.oneofMember && !jsonConfig.outputDefaultValues && !isOptionalEnum && fd.type.isDefaultValue(value)) continue
 
             val jsonValue = value
                 ?.takeUnless {

--- a/runtime/src/commonTest/kotlin/pbandk/json/JsonTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/JsonTest.kt
@@ -23,17 +23,12 @@ class JsonTest {
     fun testMessageWithEnumProto2() {
         val jsonConfig = JsonConfig.DEFAULT.copy(compactOutput = true)
 
-        // This behavior is unexpected and will be fixed in a follow-up.
-        // See https://github.com/streem/pbandk/issues/235 for more details.
         val message = MessageWithEnum()
-        assertEquals("{\"value\":null}", message.encodeToJsonString(jsonConfig))
+        assertEquals("{}", message.encodeToJsonString(jsonConfig))
 
-        // This behavior is unexpected and will be fixed in a follow-up.
-        // See https://github.com/streem/pbandk/issues/235 for more details.
         val messageWith0 = MessageWithEnum(value = MessageWithEnum.EnumType.FOO)
-        assertEquals("{}", messageWith0.encodeToJsonString(jsonConfig))
+        assertEquals("{\"value\":\"FOO\"}", messageWith0.encodeToJsonString(jsonConfig))
 
-        // This works as expected.
         val messageWith1 = MessageWithEnum(value = MessageWithEnum.EnumType.BAR)
         assertEquals("{\"value\":\"BAR\"}", messageWith1.encodeToJsonString(jsonConfig))
     }


### PR DESCRIPTION
# Note: not ready for review, waiting for guidance on https://github.com/streem/pbandk/issues/235

# Motivation

Fixes https://github.com/streem/pbandk/issues/235

# Changes

* Change the behavior for JSON serialization for optional enums.
* If unset -> don't emit on the wire.
* If set -> emit on the wire, even if the enum is set to a default value (regardless of the `jsonConfig.outputDefaultValues`)

# Tested

Run all unit tests in `runtime`