### PR TITLE
JSON serialization of default value for fields with explicit presence

### DIFF
--- a/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonMessageEncoder.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonMessageEncoder.kt
@@ -38,8 +38,9 @@ internal class JsonMessageEncoder(private val jsonConfig: JsonConfig) : MessageE
             @Suppress("UNCHECKED_CAST")
             val value = (fd.value as KProperty1<T, *>).get(message)
 
-            if (value == null && (fd.oneofMember || fd.type.hasPresence)) continue
-            if (!fd.oneofMember && !jsonConfig.outputDefaultValues && !fd.type.hasPresence && fd.type.isDefaultValue(value)) continue
+            val oneOfOrExplicitPresence = (fd.oneofMember || fd.type.hasPresence)
+            if (value == null && oneOfOrExplicitPresence) continue
+            if (!oneOfOrExplicitPresence && !jsonConfig.outputDefaultValues && fd.type.isDefaultValue(value)) continue
 
             val jsonValue = value
                 ?.takeUnless {

--- a/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonMessageEncoder.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonMessageEncoder.kt
@@ -39,7 +39,14 @@ internal class JsonMessageEncoder(private val jsonConfig: JsonConfig) : MessageE
             val value = (fd.value as KProperty1<T, *>).get(message)
 
             if (value == null && fd.oneofMember) continue
-            if (!fd.oneofMember && !jsonConfig.outputDefaultValues && fd.type.isDefaultValue(value)) continue
+
+            // For optional enums (mostly relevant for proto2) we serialize the value whenever a value is set,
+            // regardless of whether it's set to a default enum value.
+            val isOptionalEnum = (fd.type is FieldDescriptor.Type.Enum<*> && fd.type.hasPresence)
+            if (isOptionalEnum && value == null) continue
+
+            // Don't serialize other default values unless 'outputDefaultValues' is set.
+            if (!fd.oneofMember && !jsonConfig.outputDefaultValues && !isOptionalEnum && fd.type.isDefaultValue(value)) continue
 
             val jsonValue = value
                 ?.takeUnless {

--- a/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonMessageEncoder.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonMessageEncoder.kt
@@ -38,15 +38,8 @@ internal class JsonMessageEncoder(private val jsonConfig: JsonConfig) : MessageE
             @Suppress("UNCHECKED_CAST")
             val value = (fd.value as KProperty1<T, *>).get(message)
 
-            if (value == null && fd.oneofMember) continue
-
-            // For optional enums (mostly relevant for proto2) we serialize the value whenever a value is set,
-            // regardless of whether it's set to a default enum value.
-            val isOptionalEnum = (fd.type is FieldDescriptor.Type.Enum<*> && fd.type.hasPresence)
-            if (isOptionalEnum && value == null) continue
-
-            // Don't serialize other default values unless 'outputDefaultValues' is set.
-            if (!fd.oneofMember && !jsonConfig.outputDefaultValues && !isOptionalEnum && fd.type.isDefaultValue(value)) continue
+            if (value == null && (fd.oneofMember || fd.type.hasPresence)) continue
+            if (!fd.oneofMember && !jsonConfig.outputDefaultValues && !fd.type.hasPresence && fd.type.isDefaultValue(value)) continue
 
             val jsonValue = value
                 ?.takeUnless {

--- a/runtime/src/commonTest/kotlin/pbandk/json/JsonTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/JsonTest.kt
@@ -23,17 +23,12 @@ class JsonTest {
     fun testMessageWithEnumProto2() {
         val jsonConfig = JsonConfig.DEFAULT.copy(compactOutput = true)
 
-        // This behavior is unexpected and will be fixed in a follow-up.
-        // See https://github.com/streem/pbandk/issues/235 for more details.
         val message = MessageWithEnum()
-        assertEquals("{\"value\":null}", message.encodeToJsonString(jsonConfig))
+        assertEquals("{}", message.encodeToJsonString(jsonConfig))
 
-        // This behavior is unexpected and will be fixed in a follow-up.
-        // See https://github.com/streem/pbandk/issues/235 for more details.
         val messageWith0 = MessageWithEnum(value = MessageWithEnum.EnumType.FOO)
-        assertEquals("{}", messageWith0.encodeToJsonString(jsonConfig))
+        assertEquals("{\"value\":\"FOO\"}", messageWith0.encodeToJsonString(jsonConfig))
 
-        // This works as expected.
         val messageWith1 = MessageWithEnum(value = MessageWithEnum.EnumType.BAR)
         assertEquals("{\"value\":\"BAR\"}", messageWith1.encodeToJsonString(jsonConfig))
     }

--- a/runtime/src/commonTest/kotlin/pbandk/json/OutputDefaultValuesTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/OutputDefaultValuesTest.kt
@@ -29,12 +29,12 @@ class OutputDefaultValuesTest {
         assertEquals(JsonPrimitive(""), parsedJson["optionalBytes"])
         assertEquals(JsonPrimitive(TestAllTypesProto3.NestedEnum.fromValue(0).name!!), parsedJson["optionalNestedEnum"])
 
-        assertEquals(JsonNull, parsedJson["optionalNestedMessage"])
+        assertFalse(parsedJson.containsKey("optionalNestedMessage"))
 
         assertEquals(JsonArray(emptyList()), parsedJson["repeatedString"])
         assertEquals(JsonObject(emptyMap()), parsedJson["mapBoolBool"])
 
-        assertEquals(JsonNull, parsedJson["optionalStringWrapper"])
+        assertFalse(parsedJson.containsKey("optionalStringWrapper"))
         assertEquals(JsonPrimitive(false), parsedJson["optionalBoolWrapper"])
     }
 

--- a/runtime/src/commonTest/kotlin/pbandk/json/OutputDefaultValuesTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/OutputDefaultValuesTest.kt
@@ -32,12 +32,12 @@ class OutputDefaultValuesTest {
         assertEquals(JsonPrimitive(""), parsedJson["optionalBytes"])
         assertEquals(JsonPrimitive(TestAllTypesProto3.NestedEnum.fromValue(0).name!!), parsedJson["optionalNestedEnum"])
 
-        assertFalse(parsedJson.containsKey("optionalNestedMessage"))
+        assertFalse("optionalNestedMessage" in parsedJson)
 
         assertEquals(JsonArray(emptyList()), parsedJson["repeatedString"])
         assertEquals(JsonObject(emptyMap()), parsedJson["mapBoolBool"])
 
-        assertFalse(parsedJson.containsKey("optionalStringWrapper"))
+        assertFalse("optionalStringWrapper" in parsedJson)
         assertEquals(JsonPrimitive(false), parsedJson["optionalBoolWrapper"])
     }
 
@@ -55,13 +55,13 @@ class OutputDefaultValuesTest {
     @Test
     fun testProto2EnumUnsetField() {
         val message = MessageWithEnum()
-        assertEquals("{\"value\":null}", message.encodeToJsonString(jsonConfigCompactOutput))
+        assertEquals("{}", message.encodeToJsonString(jsonConfigCompactOutput))
     }
 
     @Test
     fun testProto2EnumFieldSetToDefaultValue() {
         val message = MessageWithEnum(value = MessageWithEnum.EnumType.FOO)
-        assertEquals("{}", message.encodeToJsonString(jsonConfigCompactOutput))
+        assertEquals("{\"value\":\"FOO\"}", message.encodeToJsonString(jsonConfigCompactOutput))
     }
 
     @Test


### PR DESCRIPTION
# Motivation

Fixes https://github.com/streem/pbandk/issues/235

# Changes

* Change the behavior for JSON serialization for optional fields.
* If unset -> don't emit on the wire.
* If set -> emit on the wire, even if the value is default (regardless of the `jsonConfig.outputDefaultValues`)

This is consistent with the following:
https://github.com/protocolbuffers/protobuf/blob/main/docs/field_presence.md#semantic-differences

# Tested

Run all unit tests in `runtime`